### PR TITLE
Update Tools.cs for global units

### DIFF
--- a/RoomFinishes/Tools.cs
+++ b/RoomFinishes/Tools.cs
@@ -32,7 +32,7 @@ namespace RoomFinishes
         public static double? GetValueFromString(string text, Units units)
         {
             //Check the string value
-            string heightValueString;
+            string heightValueString = text;
             double lenght;
 
             if (Autodesk.Revit.DB.UnitFormatUtils.TryParse(units, UnitType.UT_Length, heightValueString, out lenght))

--- a/RoomFinishes/Tools.cs
+++ b/RoomFinishes/Tools.cs
@@ -29,27 +29,13 @@ namespace RoomFinishes
 #endif
         }
 
-        public static double? GetValueFromString(string text)
+        public static double? GetValueFromString(string text, Units units)
         {
             //Check the string value
             string heightValueString;
             double lenght;
 
-
-            if (text.Contains(" mm"))
-            {
-                heightValueString = text.Replace(" mm", "");
-            }
-            else if (text.Contains("mm"))
-            {
-                heightValueString = text.Replace("mm", "");
-            }
-            else
-            {
-                heightValueString = text;
-            }
-
-            if (double.TryParse(heightValueString, out lenght))
+            if (Autodesk.Revit.DB.UnitFormatUtils.TryParse(units, UnitType.UT_Length, heightValueString, out lenght))
             {
                 return lenght;
             }


### PR DESCRIPTION
Add argument to GetValueFromString to receive current document Units settings.
Use Revit built-in units string parsing instead of trying to build your own with if-else statements.
Revit's own units string parsing will also convert the value to current document units, so you don't have to forcibly convert mm to feet in other files.
This should enable the add-in to handle both metric and imperial units, in any formatting that Revit normally accepts (254mm, 254 mm, 10in, 10 in, 10", etc.)
